### PR TITLE
Fix NoMethodError at Orthoses::ActiveRecord::Scope middleware

### DIFF
--- a/lib/orthoses/active_record/scope.rb
+++ b/lib/orthoses/active_record/scope.rb
@@ -20,7 +20,7 @@ module Orthoses
           name = capture.argument[:name]
           body = capture.argument[:body]
 
-          definition = "#{name}: #{parameters_to_type(body.parameters)} -> #{base_name}::ActiveRecord_Relation"
+          definition = "#{name}: #{parameters_to_type(parameters(body))} -> #{base_name}::ActiveRecord_Relation"
           store[base_name] << "def self.#{definition}"
           store["#{base_name}::GeneratedRelationMethods"].header = "module #{base_name}::GeneratedRelationMethods"
           store["#{base_name}::GeneratedRelationMethods"] << "def #{definition}"
@@ -57,6 +57,16 @@ module Orthoses
           end
         end
         "(#{res.join(", ")})#{block}"
+      end
+
+      def parameters(body)
+        if body.is_a?(Proc)
+          body.parameters
+        elsif body.respond_to?(:call)
+          body.method(:call).parameters
+        else
+          raise "unexpected: #{body} passed to scope"
+        end
       end
     end
   end

--- a/lib/orthoses/active_record/scope.rb
+++ b/lib/orthoses/active_record/scope.rb
@@ -60,12 +60,10 @@ module Orthoses
       end
 
       def parameters(body)
-        if body.is_a?(Proc)
-          body.parameters
-        elsif body.respond_to?(:call)
-          body.method(:call).parameters
+        if body.respond_to?(:to_proc)
+          body.to_proc.parameters
         else
-          raise "unexpected: #{body} passed to scope"
+          body.method(:call).parameters
         end
       end
     end


### PR DESCRIPTION
When passing callable object to scope

e.g. using Query Object Pattern
c.f. https://takaokouji.github.io/output/query-object/

```ruby
class FilterByStatusQuery
  private attr_reader :relation, :options

  def self.call(*args)
    new(*args).send(:query)
  end

  def initialize(*args)
    @options = args.extract_options!
    @relation = Blog
  end

  private

  def query
    relation.where(status: options[:status])
  end
end

class Blog < ApplicationRecord
  scope :by_status, FilterByStatusQuery
end
```

Orthoses raises NoMethodError because Class doesn't respond to parameters

```
$ bin/rails orthoses:rails

...

Caused by:
NoMethodError: undefined method `parameters' for FilterByStatusQuery:Class (NoMethodError)

          definition = "#{name}: #{parameters_to_type(body.parameters)} -> #{base_name}::ActiveRecord_Relation"
                                                          ^^^^^^^^^^^
```

So captured argument body is not Proc and callable, we should use Method#parameters