### PR TITLE
Fix glob pattern in Rake task

### DIFF
--- a/lib/generators/orthoses/rails/templates/rails.rake
+++ b/lib/generators/orthoses/rails/templates/rails.rake
@@ -22,7 +22,7 @@ namespace :orthoses do
       # By using this middleware, you can add the capability
       # to generate type information from YARD documentation.
       # use Orthoses::YARD,
-      #   parse: ['{app/lib}/**/*.rb']
+      #   parse: ['{app,lib}/**/*.rb']
 
       # You can load hand written RBS.
       # use Orthoses::LoadRBS,


### PR DESCRIPTION
The pattern was incorrect and only matched `app/lib/**/*.rb`.
This commit fixes the pattern to target `app/**/*.rb` and `lib/**/*.rb`.
