### PR TITLE
Automatically follow the latest version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,5 +35,5 @@ jobs:
         bundler-cache: true
     - name: Run the default task
       run: |
-        bundle exec rbs collection install
+        bundle exec rbs collection update
         bundle exec rake


### PR DESCRIPTION
Fix CI breaks when rbs is versioned up.

The method is a bit aggressive, but it solves the problem reasonably.