### PR TITLE
Support unstrict enum union type

### DIFF
--- a/lib/orthoses/active_record/enum.rb
+++ b/lib/orthoses/active_record/enum.rb
@@ -7,9 +7,9 @@ module Orthoses
     # >= 7.0
     #   def enum(name = nil, values = nil, **options)
     class Enum
-      def initialize(loader, strict: false)
+      def initialize(loader, strict_limit: 8)
         @loader = loader
-        @strict = strict
+        @strict_limit = strict_limit
       end
 
       def call
@@ -86,7 +86,7 @@ module Orthoses
 
         # Expressing type casting.
         overloads = [] #: Array[String]
-        if @strict
+        if pairs.length <= @strict_limit
           if pairs.keys.any? { |key| key.match?(/[^a-zA-Z_]/) }
             overloads << "(Symbol) -> void"
           else

--- a/lib/orthoses/active_record/enum.rb
+++ b/lib/orthoses/active_record/enum.rb
@@ -7,8 +7,9 @@ module Orthoses
     # >= 7.0
     #   def enum(name = nil, values = nil, **options)
     class Enum
-      def initialize(loader)
+      def initialize(loader, strict: false)
         @loader = loader
+        @strict = strict
       end
 
       def call
@@ -84,18 +85,23 @@ module Orthoses
         end
 
         # Expressing type casting.
-        store[base_name] << "def #{name}: () -> (#{pairs.keys.map { |k| "\"#{k}\"" }.join(" | ")})"
-        symbol_pattern = if pairs.keys.any? { |key| key.match?(/[^a-zA-Z_]/) }
-          "(Symbol) -> void"
+        overloads = [] #: Array[String]
+        if @strict
+          if pairs.keys.any? { |key| key.match?(/[^a-zA-Z_]/) }
+            overloads << "(Symbol) -> void"
+          else
+            overloads << "(#{pairs.keys.map{|key|key.to_sym.inspect}.join(" | ")}) -> void"
+          end
+          overloads << "(#{pairs.keys.map{|key|key.to_s.inspect}.join(" | ")}) -> void"
+          overloads << "(#{pairs.values.map(&:inspect).join(" | ")}) -> void"
+          store[base_name] << "def #{name}: () -> (#{pairs.keys.map { |k| "\"#{k}\"" }.join(" | ")})"
+          store[base_name] << "def #{name}=: #{overloads.join(" | ")}"
         else
-          "(#{pairs.keys.map{|key|key.to_sym.inspect}.join(" | ")}) -> void"
+          overloads << "(Symbol | String) -> void"
+          overloads << "(#{pairs.values.map { |v| Orthoses::Utils.object_to_rbs(v) }.uniq.join(" | ")}) -> void"
+          store[base_name] << "def #{name}: () -> String"
+          store[base_name] << "def #{name}=: #{overloads.join(" | ")}"
         end
-        overloads = [
-          symbol_pattern,
-          "(#{pairs.keys.map{|key|key.to_s.inspect}.join(" | ")}) -> void",
-          "(#{pairs.values.map(&:inspect).join(" | ")}) -> void",
-        ]
-        store[base_name] << "def #{name}=: #{overloads.join(" | ")}"
       end
     end
   end

--- a/lib/orthoses/active_record/enum_test.rb
+++ b/lib/orthoses/active_record/enum_test.rb
@@ -14,17 +14,9 @@ module EnumTest
     end
   }
 
-  LOADER2 = ->(){
-    class User2 < ActiveRecord::Base
-      enum :array, [ :array_active, :array_archived ]
-      enum :map, { map_active: "active", map_archived: "archived" }
-    end
-  }
-
   def test_enum(t)
     store = Orthoses::ActiveRecord::Enum.new(
       Orthoses::Store.new(LOADER1),
-      strict: false
     ).call
 
     actual = store["EnumTest::User1"].to_rbs
@@ -32,25 +24,30 @@ module EnumTest
       class EnumTest::User1 < ::ActiveRecord::Base
         include EnumTest::User1::ActiveRecord_Enum_EnumMethods
         def self.arrays: () -> ActiveSupport::HashWithIndifferentAccess[String, Integer]
-        def array: () -> String
-        def array=: (Symbol | String) -> void
-                  | (Integer) -> void
+        def array: () -> ("array_active" | "array_archived")
+        def array=: (:array_active | :array_archived) -> void
+                  | ("array_active" | "array_archived") -> void
+                  | (0 | 1) -> void
         def self.maps: () -> ActiveSupport::HashWithIndifferentAccess[String, String]
-        def map: () -> String
-        def map=: (Symbol | String) -> void
-                | (String) -> void
+        def map: () -> ("map_active" | "map_archived")
+        def map=: (:map_active | :map_archived) -> void
+                | ("map_active" | "map_archived") -> void
+                | ("active" | "archived") -> void
         def self.prefs: () -> ActiveSupport::HashWithIndifferentAccess[String, Integer]
-        def pref: () -> String
-        def pref=: (Symbol | String) -> void
-                 | (Integer) -> void
+        def pref: () -> ("active" | "archived")
+        def pref=: (:active | :archived) -> void
+                 | ("active" | "archived") -> void
+                 | (0 | 1) -> void
         def self.suffs: () -> ActiveSupport::HashWithIndifferentAccess[String, Integer]
-        def suff: () -> String
-        def suff=: (Symbol | String) -> void
-                 | (Integer) -> void
+        def suff: () -> ("active" | "archived")
+        def suff=: (:active | :archived) -> void
+                 | ("active" | "archived") -> void
+                 | (0 | 1) -> void
         def self.escapes: () -> ActiveSupport::HashWithIndifferentAccess[String, Integer]
-        def escape: () -> String
-        def escape=: (Symbol | String) -> void
-                   | (Integer) -> void
+        def escape: () -> ("a-b-c" | "e_[]_f")
+        def escape=: (Symbol) -> void
+                   | ("a-b-c" | "e_[]_f") -> void
+                   | (0 | 1) -> void
       end
     RBS
     unless expect == actual
@@ -112,10 +109,17 @@ module EnumTest
     unless expect == actual
       t.error("expect=\n```rbs\n#{expect}```\n, but got \n```rbs\n#{actual}```\n")
     end
+  end
 
+  LOADER2 = ->(){
+    class User2 < ActiveRecord::Base
+      enum :array, %i[a b c d e f g h i]
+    end
+  }
+
+  def test_enum_unstrict(t)
     store = Orthoses::ActiveRecord::Enum.new(
       Orthoses::Store.new(LOADER2),
-      strict: true
     ).call
 
     actual = store["EnumTest::User2"].to_rbs
@@ -123,15 +127,9 @@ module EnumTest
       class EnumTest::User2 < ::ActiveRecord::Base
         include EnumTest::User2::ActiveRecord_Enum_EnumMethods
         def self.arrays: () -> ActiveSupport::HashWithIndifferentAccess[String, Integer]
-        def array: () -> ("array_active" | "array_archived")
-        def array=: (:array_active | :array_archived) -> void
-                  | ("array_active" | "array_archived") -> void
-                  | (0 | 1) -> void
-        def self.maps: () -> ActiveSupport::HashWithIndifferentAccess[String, String]
-        def map: () -> ("map_active" | "map_archived")
-        def map=: (:map_active | :map_archived) -> void
-                | ("map_active" | "map_archived") -> void
-                | ("active" | "archived") -> void
+        def array: () -> String
+        def array=: (Symbol | String) -> void
+                  | (Integer) -> void
       end
     RBS
     unless expect == actual
@@ -141,21 +139,41 @@ module EnumTest
     actual = store["EnumTest::User2::ActiveRecord_Enum_EnumMethods"].to_rbs
     expect = <<~RBS
       module EnumTest::User2::ActiveRecord_Enum_EnumMethods
-        def array_active?: () -> bool
+        def a?: () -> bool
 
-        def array_active!: () -> bool
+        def a!: () -> bool
 
-        def array_archived?: () -> bool
+        def b?: () -> bool
 
-        def array_archived!: () -> bool
+        def b!: () -> bool
 
-        def map_active?: () -> bool
+        def c?: () -> bool
 
-        def map_active!: () -> bool
+        def c!: () -> bool
 
-        def map_archived?: () -> bool
+        def d?: () -> bool
 
-        def map_archived!: () -> bool
+        def d!: () -> bool
+
+        def e?: () -> bool
+
+        def e!: () -> bool
+
+        def f?: () -> bool
+
+        def f!: () -> bool
+
+        def g?: () -> bool
+
+        def g!: () -> bool
+
+        def h?: () -> bool
+
+        def h!: () -> bool
+
+        def i?: () -> bool
+
+        def i!: () -> bool
       end
     RBS
     unless expect == actual

--- a/lib/orthoses/active_record/enum_test.rb
+++ b/lib/orthoses/active_record/enum_test.rb
@@ -13,9 +13,18 @@ module EnumTest
       enum :escape, [:"a-b-c", :"e_[]_f"]
     end
   }
+
+  LOADER2 = ->(){
+    class User2 < ActiveRecord::Base
+      enum :array, [ :array_active, :array_archived ]
+      enum :map, { map_active: "active", map_archived: "archived" }
+    end
+  }
+
   def test_enum(t)
     store = Orthoses::ActiveRecord::Enum.new(
-      Orthoses::Store.new(LOADER1)
+      Orthoses::Store.new(LOADER1),
+      strict: false
     ).call
 
     actual = store["EnumTest::User1"].to_rbs
@@ -23,30 +32,25 @@ module EnumTest
       class EnumTest::User1 < ::ActiveRecord::Base
         include EnumTest::User1::ActiveRecord_Enum_EnumMethods
         def self.arrays: () -> ActiveSupport::HashWithIndifferentAccess[String, Integer]
-        def array: () -> ("array_active" | "array_archived")
-        def array=: (:array_active | :array_archived) -> void
-                  | ("array_active" | "array_archived") -> void
-                  | (0 | 1) -> void
+        def array: () -> String
+        def array=: (Symbol | String) -> void
+                  | (Integer) -> void
         def self.maps: () -> ActiveSupport::HashWithIndifferentAccess[String, String]
-        def map: () -> ("map_active" | "map_archived")
-        def map=: (:map_active | :map_archived) -> void
-                | ("map_active" | "map_archived") -> void
-                | ("active" | "archived") -> void
+        def map: () -> String
+        def map=: (Symbol | String) -> void
+                | (String) -> void
         def self.prefs: () -> ActiveSupport::HashWithIndifferentAccess[String, Integer]
-        def pref: () -> ("active" | "archived")
-        def pref=: (:active | :archived) -> void
-                 | ("active" | "archived") -> void
-                 | (0 | 1) -> void
+        def pref: () -> String
+        def pref=: (Symbol | String) -> void
+                 | (Integer) -> void
         def self.suffs: () -> ActiveSupport::HashWithIndifferentAccess[String, Integer]
-        def suff: () -> ("active" | "archived")
-        def suff=: (:active | :archived) -> void
-                 | ("active" | "archived") -> void
-                 | (0 | 1) -> void
+        def suff: () -> String
+        def suff=: (Symbol | String) -> void
+                 | (Integer) -> void
         def self.escapes: () -> ActiveSupport::HashWithIndifferentAccess[String, Integer]
-        def escape: () -> ("a-b-c" | "e_[]_f")
-        def escape=: (Symbol) -> void
-                   | ("a-b-c" | "e_[]_f") -> void
-                   | (0 | 1) -> void
+        def escape: () -> String
+        def escape=: (Symbol | String) -> void
+                   | (Integer) -> void
       end
     RBS
     unless expect == actual
@@ -103,6 +107,55 @@ module EnumTest
         def e___f?: () -> bool
 
         def e___f!: () -> bool
+      end
+    RBS
+    unless expect == actual
+      t.error("expect=\n```rbs\n#{expect}```\n, but got \n```rbs\n#{actual}```\n")
+    end
+
+    store = Orthoses::ActiveRecord::Enum.new(
+      Orthoses::Store.new(LOADER2),
+      strict: true
+    ).call
+
+    actual = store["EnumTest::User2"].to_rbs
+    expect = <<~RBS
+      class EnumTest::User2 < ::ActiveRecord::Base
+        include EnumTest::User2::ActiveRecord_Enum_EnumMethods
+        def self.arrays: () -> ActiveSupport::HashWithIndifferentAccess[String, Integer]
+        def array: () -> ("array_active" | "array_archived")
+        def array=: (:array_active | :array_archived) -> void
+                  | ("array_active" | "array_archived") -> void
+                  | (0 | 1) -> void
+        def self.maps: () -> ActiveSupport::HashWithIndifferentAccess[String, String]
+        def map: () -> ("map_active" | "map_archived")
+        def map=: (:map_active | :map_archived) -> void
+                | ("map_active" | "map_archived") -> void
+                | ("active" | "archived") -> void
+      end
+    RBS
+    unless expect == actual
+      t.error("expect=\n```rbs\n#{expect}```\n, but got \n```rbs\n#{actual}```\n")
+    end
+
+    actual = store["EnumTest::User2::ActiveRecord_Enum_EnumMethods"].to_rbs
+    expect = <<~RBS
+      module EnumTest::User2::ActiveRecord_Enum_EnumMethods
+        def array_active?: () -> bool
+
+        def array_active!: () -> bool
+
+        def array_archived?: () -> bool
+
+        def array_archived!: () -> bool
+
+        def map_active?: () -> bool
+
+        def map_active!: () -> bool
+
+        def map_archived?: () -> bool
+
+        def map_archived!: () -> bool
       end
     RBS
     unless expect == actual


### PR DESCRIPTION
Too many union types are steep and there are concerns about performance degradation.