### PR TITLE
Support annotation `implicitly-returns-nil`

### DIFF
--- a/lib/orthoses/active_record/belongs_to.rb
+++ b/lib/orthoses/active_record/belongs_to.rb
@@ -23,7 +23,7 @@ module Orthoses
               opt = "#{type}?"
 
               [
-                "def #{ref.name}: () -> #{opt}",
+                "%a{implicitly-returns-nil} def #{ref.name}: () -> #{type}",
                 "def #{ref.name}=: (#{opt}) -> #{opt}",
                 "def reload_#{ref.name}: () -> #{opt}",
               ].tap do |ary|

--- a/lib/orthoses/active_record/belongs_to_test.rb
+++ b/lib/orthoses/active_record/belongs_to_test.rb
@@ -1,3 +1,8 @@
+begin
+  require 'test_helper'
+rescue LoadError
+end
+
 module BelongsToTest
   LOADER = ->(){
     class User < ActiveRecord::Base
@@ -40,7 +45,8 @@ module BelongsToTest
 
     expect = <<~RBS
       module BelongsToTest::Post::GeneratedAssociationMethods
-        def user: () -> BelongsToTest::User?
+        %a{implicitly-returns-nil}
+        def user: () -> BelongsToTest::User
 
         def user=: (BelongsToTest::User?) -> BelongsToTest::User?
 


### PR DESCRIPTION
Previously, associations defined with `belongs_to` considered the possibility of returning `nil`, but this was not very convenient.  

In most cases, the model can be retrieved, and `nil` is returned only in rare cases. In such situations, the `%a{implicitly-returns-nil}` annotation is the best choice.