### PR TITLE
Reduce mixin signatures

### DIFF
--- a/lib/orthoses/active_record/relation.rb
+++ b/lib/orthoses/active_record/relation.rb
@@ -3,8 +3,9 @@
 module Orthoses
   module ActiveRecord
     class Relation
-      def initialize(loader)
+      def initialize(loader, strict: false)
         @loader = loader
+        @strict = strict
       end
 
       def call
@@ -24,10 +25,12 @@ module Orthoses
               klass.singleton_methods(false).each do |singleton_method|
                 c << "def #{singleton_method}: (*untyped, **untyped) -> untyped"
               end
-              (klass.singleton_class.included_modules - ::ActiveRecord::Relation.included_modules).each do |mod|
-                mname = Utils.module_name(mod) or next
-                store[mname].header = "module #{mname}"
-                c << "include #{mname}"
+              if @strict
+                (klass.singleton_class.included_modules - ::ActiveRecord::Relation.included_modules).each do |mod|
+                  mname = Utils.module_name(mod) or next
+                  store[mname].header = "module #{mname}"
+                  c << "include #{mname}"
+                end
               end
             end
 

--- a/lib/orthoses/active_record/relation_test.rb
+++ b/lib/orthoses/active_record/relation_test.rb
@@ -63,14 +63,12 @@ module RelationTest
       t.error("expect=\n```rbs\n#{expect}```\n, but got \n```rbs\n#{actual}```\n")
     end
 
+    expect = [
+      'def singleton!:'
+    ]
     actual = store["RelationTest::User::GeneratedRelationMethods"].to_rbs
-    expect = <<~RBS
-      module RelationTest::User::GeneratedRelationMethods
-        def singleton!: (*untyped, **untyped) -> untyped
-      end
-    RBS
-    unless expect == actual
-      t.error("expect=\n```rbs\n#{expect}```\n, but got \n```rbs\n#{actual}```\n")
+    unless expect.all? { |e| actual.include?(e) }
+      t.error("expect has #{expect}, but got \n```rbs\n#{actual}```\n")
     end
   end
 end

--- a/lib/orthoses/active_record/relation_test.rb
+++ b/lib/orthoses/active_record/relation_test.rb
@@ -63,13 +63,14 @@ module RelationTest
       t.error("expect=\n```rbs\n#{expect}```\n, but got \n```rbs\n#{actual}```\n")
     end
 
-    expect = [
-      'def singleton!:',
-      'include ActiveRecord::Core::ClassMethods'
-    ]
     actual = store["RelationTest::User::GeneratedRelationMethods"].to_rbs
-    unless expect.all? { |e| actual.include?(e) }
-      t.error("expect has #{expect}, but got \n```rbs\n#{actual}```\n")
+    expect = <<~RBS
+      module RelationTest::User::GeneratedRelationMethods
+        def singleton!: (*untyped, **untyped) -> untyped
+      end
+    RBS
+    unless expect == actual
+      t.error("expect=\n```rbs\n#{expect}```\n, but got \n```rbs\n#{actual}```\n")
     end
   end
 end


### PR DESCRIPTION
Due to the large number of mixins, convenience is significantly reduced due to performance degradation rather than comprehensiveness. The default is to give priority to performance.