### PR TITLE
Custom targets for GeneratedAttributeMethods

### DIFF
--- a/lib/orthoses/active_record/generated_attribute_methods.rb
+++ b/lib/orthoses/active_record/generated_attribute_methods.rb
@@ -25,8 +25,9 @@ module Orthoses
         "will_save_change_to_attribute?" => "() -> bool",
       }
 
-      def initialize(loader)
+      def initialize(loader, target_type_map: TARGET_TYPE_MAP)
         @loader = loader
+        @target_type_map = target_type_map
       end
 
       def call
@@ -50,7 +51,7 @@ module Orthoses
 
               lines << "attr_accessor #{name}: #{type}"
               attribute_method_patterns(::ActiveRecord::Base).each do |matcher|
-                tmpl = TARGET_TYPE_MAP[matcher.proxy_target] or next
+                tmpl = @target_type_map[matcher.proxy_target] or next
                 lines << "def #{matcher.method_name(name)}: #{tmpl % {type: type, opt: opt}}"
               end
             end

--- a/lib/orthoses/active_record/generated_attribute_methods.rb
+++ b/lib/orthoses/active_record/generated_attribute_methods.rb
@@ -25,9 +25,12 @@ module Orthoses
         "will_save_change_to_attribute?" => "() -> bool",
       }
 
-      def initialize(loader, target_type_map: TARGET_TYPE_MAP)
+      def initialize(loader, targets: TARGET_TYPE_MAP.keys)
         @loader = loader
-        @target_type_map = target_type_map
+        unless targets.all? { |target| TARGET_TYPE_MAP.key?(target) }
+          raise ArgumentError, "Unknown target type: #{targets - TARGET_TYPE_MAP.keys}"
+        end
+        @targets = targets
       end
 
       def call
@@ -51,12 +54,13 @@ module Orthoses
 
               lines << "attr_accessor #{name}: #{type}"
               attribute_method_patterns(::ActiveRecord::Base).each do |matcher|
-                tmpl = @target_type_map[matcher.proxy_target] or next
+                tmpl = target_type(matcher.proxy_target) or next
                 lines << "def #{matcher.method_name(name)}: #{tmpl % {type: type, opt: opt}}"
               end
             end
             klass.attribute_aliases.each do |alias_name, column_name|
               attribute_method_patterns(::ActiveRecord::Base).each do |matcher|
+                next unless matcher.proxy_target == "attribute" || target_type(matcher.proxy_target)
                 lines << "alias #{matcher.method_name(alias_name)} #{matcher.method_name(column_name)}"
               end
             end
@@ -82,6 +86,11 @@ module Orthoses
             end
           end
         end
+      end
+
+      def target_type(target)
+        return unless @targets.include?(target)
+        TARGET_TYPE_MAP[target]
       end
     end
   end


### PR DESCRIPTION
`GeneratedAttributeMethods` methods tend to be numerous and affect type checking performance.
Allows users to adjust methods that are not in use.