### PR TITLE
Support class specific GeneratedRelationMethods for CollectionProxy

### DIFF
--- a/lib/orthoses/active_record/relation.rb
+++ b/lib/orthoses/active_record/relation.rb
@@ -43,6 +43,7 @@ module Orthoses
 
             store[class_specific_proxy].tap do |c|
               c.header = "class #{class_specific_proxy} < ::ActiveRecord::Associations::CollectionProxy"
+              c << "include #{class_specific_generated_relation_methods}"
               c << "include _ActiveRecord_Relation[#{model_name}, #{primary_key}]"
               c << "include Enumerable[#{model_name}]"
             end

--- a/lib/orthoses/active_record/relation_test.rb
+++ b/lib/orthoses/active_record/relation_test.rb
@@ -45,6 +45,7 @@ module RelationTest
 
     expect = <<~RBS
       class RelationTest::User::ActiveRecord_Associations_CollectionProxy < ::ActiveRecord::Associations::CollectionProxy
+        include RelationTest::User::GeneratedRelationMethods
         include _ActiveRecord_Relation[RelationTest::User, ::Integer]
         include Enumerable[RelationTest::User]
       end


### PR DESCRIPTION
The following links are the basis.

- https://github.com/rails/rails/blob/main/activerecord/lib/active_record/base.rb#L296
- https://github.com/rails/rails/blob/ad858b91a9a4bc94950708955e44c654a1f3789b/activerecord/lib/active_record/relation/delegation.rb#L47
- https://github.com/rails/rails/blob/ad858b91a9a4bc94950708955e44c654a1f3789b/activerecord/lib/active_record/relation/delegation.rb#L31-L44
  - https://github.com/rails/rails/blob/ad858b91a9a4bc94950708955e44c654a1f3789b/activerecord/lib/active_record/relation/delegation.rb#L10
  - https://github.com/rails/rails/blob/ad858b91a9a4bc94950708955e44c654a1f3789b/activerecord/lib/active_record/relation/delegation.rb#L58
  - https://github.com/rails/rails/blob/ad858b91a9a4bc94950708955e44c654a1f3789b/activerecord/lib/active_record/relation/delegation.rb#L62-L67