### PR TITLE
Fix `NoMethodError in Orthoses::ActiveSupport::Delegation::Resource#resolve_type_by_name`

### DIFF
--- a/lib/orthoses/active_support/delegation.rb
+++ b/lib/orthoses/active_support/delegation.rb
@@ -129,7 +129,8 @@ module Orthoses
                 return [:multi, member.overloads.map { |o| o.method_type }]
               else
                 method_type = member.overloads.map(&:method_type).find do |method_type|
-                  method_type.type.required_positionals.empty? && method_type.type.required_keywords.empty?
+                  is_untyped_function = defined?(RBS::Types::UntypedFunction) && method_type.type.is_a?(RBS::Types::UntypedFunction)
+                  is_untyped_function || (method_type.type.required_positionals.empty? && method_type.type.required_keywords.empty?)
                 end
                 next unless method_type
                 return [:single, method_type.type.return_type]

--- a/lib/orthoses/active_support/delegation_test.rb
+++ b/lib/orthoses/active_support/delegation_test.rb
@@ -19,6 +19,7 @@ module DelegationTest
       delegate :ord, to: :single_alias
       delegate :even?, to: :defined
       delegate :from_bar, to: :to_bar
+      delegate :ref_untyped_function, to: :untyped_function
     end
   }
   def test_delegate(t)
@@ -40,6 +41,7 @@ module DelegationTest
         store["DelegationTest::Foo"] << "alias single_alias string"
         store["DelegationTest::Foo"] << "SINGLE_CONST: Integer"
         store["DelegationTest::Foo"] << "def to_bar: () -> DelegationTest::Bar"
+        store["DelegationTest::Foo"] << "def untyped_function: (?) -> untyped"
         store["DelegationTest::Bar"].header = "class Bar"
         store["DelegationTest::Bar"] << "def from_bar: () -> DelegationTest::Bar"
         store["DelegationTest::Bar"] << "private def priv: () -> void"
@@ -59,6 +61,7 @@ module DelegationTest
         alias single_alias string
         SINGLE_CONST: Integer
         def to_bar: () -> DelegationTest::Bar
+        def untyped_function: (?) -> untyped
         def name: () -> ::String
         def ref_no_type: (?) -> untyped
         def skip: (?) -> untyped
@@ -69,6 +72,7 @@ module DelegationTest
         def ord: () -> ::Integer
         def even?: () -> bool
         def from_bar: () -> DelegationTest::Bar
+        def ref_untyped_function: (?) -> untyped
       end
     RBS
     unless expect == actual


### PR DESCRIPTION
## Motivation / Background

If the rbs version is 3.6.0 or higher, and there are any delegations to `UntypedFunction`, `NoMethodError` is raised in `Orthoses::ActiveSupport::Delegation::Resource#resolve_type_by_name`.

```
NoMethodError: undefined method 'required_positionals' for an instance of RBS::Types::UntypedFunction (NoMethodError)

                  method_type.type.required_positionals.empty? && method_type.type.required_keywords.empty?
                                  ^^^^^^^^^^^^^^^^^^^^^
/xxx/orthoses-rails/lib/orthoses/active_support/delegation.rb:135:in 'block (2 levels) in Orthoses::ActiveSupport::Delegation::Resource#resolve_type_by_name'
/xxx/orthoses-rails/lib/orthoses/active_support/delegation.rb:133:in 'Array#each'
/xxx/orthoses-rails/lib/orthoses/active_support/delegation.rb:133:in 'Enumerable#find'
/xxx/orthoses-rails/lib/orthoses/active_support/delegation.rb:133:in 'block in Orthoses::ActiveSupport::Delegation::Resource#resolve_type_by_name'
/xxx/orthoses-rails/lib/orthoses/active_support/delegation.rb:125:in 'Array#each'
/xxx/orthoses-rails/lib/orthoses/active_support/delegation.rb:125:in 'Orthoses::ActiveSupport::Delegation::Resource#resolve_type_by_name'
/xxx/orthoses-rails/lib/orthoses/active_support/delegation.rb:90:in 'Orthoses::ActiveSupport::Delegation::Resource#find'
/xxx/orthoses-rails/lib/orthoses/active_support/delegation.rb:40:in 'block in Orthoses::ActiveSupport::Delegation#call'
/xxx/orthoses-rails/lib/orthoses/active_support/delegation.rb:20:in 'Array#each'
/xxx/orthoses-rails/lib/orthoses/active_support/delegation.rb:20:in 'Orthoses::ActiveSupport::Delegation#call'
/xxx/orthoses-rails/lib/orthoses/active_support/delegation_test.rb:52:in 'DelegationTest#test_delegate'
/xxx/orthoses-rails/Rakefile:9:in 'block in <top (required)>'
/xxx/.rbenv/versions/3.4.3/bin/bundle:25:in 'Kernel#load'
/xxx/.rbenv/versions/3.4.3/bin/bundle:25:in '<main>'
```

This is the same issue as [Shopify/ruby-lsp#2631](https://github.com/Shopify/ruby-lsp/pull/2631).

## Detail

I changed it to return true without checking the arguments if it is a version with `RBS::Types::UntypedFunction` added and `method_type.type` is `UntypedFunction`.

cf. https://github.com/Shopify/ruby-lsp/pull/2631/files#diff-c78eb7ee51b85f358cb7a6e80ec32d09eece5422e84083b74cd6c646d819d055R154