### PR TITLE
fix(application): Fix unexpected scope definition drop on GeneratedRelationMethods

### DIFF
--- a/lib/orthoses/rails/application.rb
+++ b/lib/orthoses/rails/application.rb
@@ -29,8 +29,8 @@ module Orthoses
           use Orthoses::ActiveRecord::HasMany
           use Orthoses::ActiveRecord::HasOne
           use Orthoses::ActiveRecord::Persistence
-          use Orthoses::ActiveRecord::Relation
           use Orthoses::ActiveRecord::Scope
+          use Orthoses::ActiveRecord::Relation
           use Orthoses::ActiveRecord::SecureToken
 
           if defined?(::ActiveStorage)

--- a/lib/orthoses/rails/application_test.rb
+++ b/lib/orthoses/rails/application_test.rb
@@ -36,29 +36,47 @@ module ApplicationTest
       Orthoses::Store.new(LOADER)
     ).call
 
-    actual = store.fetch_values('ApplicationTest::User', 'ApplicationTest::User::GeneratedRelationMethods').map(&:to_rbs).join("\n")
-    expect = <<~RBS
-      class ApplicationTest::User < ::ActiveRecord::Base
-        extend _ActiveRecord_Relation_ClassMethods[ApplicationTest::User, ApplicationTest::User::ActiveRecord_Relation, ::Integer]
-        def self.empty: () -> ApplicationTest::User::ActiveRecord_Relation
-        def self.params: (untyped a, ?untyped b, *untyped, d: untyped, ?e: untyped, **untyped) -> ApplicationTest::User::ActiveRecord_Relation
-        def self.by_status: (?) -> ApplicationTest::User::ActiveRecord_Relation
-        extend ApplicationTest::User::ActiveRecord_Persistence_ClassMethods
-        include ApplicationTest::User::GeneratedAssociationMethods
-        include ApplicationTest::User::GeneratedAttributeMethods
-      end
+    user_signature = store.fetch('ApplicationTest::User').to_rbs
 
-      module ApplicationTest::User::GeneratedRelationMethods
-        def params: (untyped a, ?untyped b, *untyped, d: untyped, ?e: untyped, **untyped) -> ApplicationTest::User::ActiveRecord_Relation
-
-        def by_status: (?) -> ApplicationTest::User::ActiveRecord_Relation
-
-        def empty: () -> ApplicationTest::User::ActiveRecord_Relation
-      end
-    RBS
-    unless expect == actual
-      t.error("expect=\n```rbs\n#{expect}```\n, but got \n```rbs\n#{actual}```\n")
+    /(def self\.empty:.*$)/.match(user_signature) => [actual_user_empty_signature]
+    expect_user_empty_signature = 'def self.empty: () -> ApplicationTest::User::ActiveRecord_Relation'
+    unless expect_user_empty_signature == actual_user_empty_signature
+      t.error("expect=\n```rbs\n#{expect_user_empty_signature}```\n, but got \n```rbs\n#{actual_user_empty_signature}```\n")
     end
+
+    /(def self\.params:.*$)/.match(user_signature) => [actual_user_params_signature]
+    expect_user_params_signature = 'def self.params: (untyped a, ?untyped b, *untyped, d: untyped, ?e: untyped, **untyped) -> ApplicationTest::User::ActiveRecord_Relation'
+    unless expect_user_params_signature == actual_user_params_signature
+      t.error("expect=\n```rbs\n#{expect_user_params_signature}```\n, but got \n```rbs\n#{actual_user_params_signature}```\n")
+    end
+
+    /(def self\.by_status:.*$)/.match(user_signature) => [actual_user_by_status_signature]
+    expect_user_by_status_signature = 'def self.by_status: (?) -> ApplicationTest::User::ActiveRecord_Relation'
+    unless expect_user_by_status_signature == actual_user_by_status_signature
+      t.error("expect=\n```rbs\n#{expect_user_by_status_signature}```\n, but got \n```rbs\n#{actual_user_by_status_signature}```\n")
+    end
+
+    generated_relation_methods_signature = store.fetch('ApplicationTest::User::GeneratedRelationMethods').to_rbs
+
+    /(def empty:.*$)/.match(generated_relation_methods_signature) => [actual_generated_relation_methods_empty_signature]
+    expect_generated_relation_methods_empty_signature = 'def empty: () -> ApplicationTest::User::ActiveRecord_Relation'
+    unless expect_generated_relation_methods_empty_signature == actual_generated_relation_methods_empty_signature
+      t.error("expect=\n```rbs\n#{expect_generated_relation_methods_empty_signature}```\n, but got \n```rbs\n#{actual_generated_relation_methods_empty_signature}```\n")
+    end
+
+    /(def params:.*$)/.match(generated_relation_methods_signature) => [actual_generated_relation_methods_params_signature]
+    expect_generated_relation_methods_params_signature = 'def params: (untyped a, ?untyped b, *untyped, d: untyped, ?e: untyped, **untyped) -> ApplicationTest::User::ActiveRecord_Relation'
+    unless expect_generated_relation_methods_params_signature == actual_generated_relation_methods_params_signature
+      t.error("expect=\n```rbs\n#{expect_generated_relation_methods_params_signature}```\n, but got \n```rbs\n#{actual_generated_relation_methods_params_signature}```\n")
+    end
+
+    /(def by_status:.*$)/.match(generated_relation_methods_signature) => [actual_generated_relation_methods_by_status_signature]
+    expect_generated_relation_methods_by_status_signature = 'def by_status: (?) -> ApplicationTest::User::ActiveRecord_Relation'
+    unless expect_generated_relation_methods_by_status_signature == actual_generated_relation_methods_by_status_signature
+      t.error("expect=\n```rbs\n#{expect_generated_relation_methods_by_status_signature}```\n, but got \n```rbs\n#{actual_generated_relation_methods_by_status_signature}```\n")
+    end
+  rescue NoMatchingPatternError, KeyError => e
+    t.error(e.full_message)
   end
 
   def test_check_typo_only(t)

--- a/lib/orthoses/rails/application_test.rb
+++ b/lib/orthoses/rails/application_test.rb
@@ -4,6 +4,63 @@ rescue LoadError
 end
 
 module ApplicationTest
+  LOADER = ->(){
+    class FilterByStatusQuery
+      private attr_reader :relation, :options
+
+      def self.call(...)
+        new(...).send(:query)
+      end
+
+      def initialize(*args)
+        @options = args.extract_options!
+        @relation = Blog
+      end
+
+      private
+
+      def query
+        relation.where(status: options[:status])
+      end
+    end
+
+    class User < ActiveRecord::Base
+      scope :empty, -> () { }
+      scope :params, -> (a, b = 1, *c, d:, e: 2, **f) { }
+      scope :by_status, FilterByStatusQuery
+    end
+  }
+
+  def test_generated_relation_methods_by_scope(t)
+    store = Orthoses::Rails::Application.new(
+      Orthoses::Store.new(LOADER)
+    ).call
+
+    actual = store.fetch_values('ApplicationTest::User', 'ApplicationTest::User::GeneratedRelationMethods').map(&:to_rbs).join("\n")
+    expect = <<~RBS
+      class ApplicationTest::User < ::ActiveRecord::Base
+        extend _ActiveRecord_Relation_ClassMethods[ApplicationTest::User, ApplicationTest::User::ActiveRecord_Relation, ::Integer]
+        def self.empty: () -> ApplicationTest::User::ActiveRecord_Relation
+        def self.params: (untyped a, ?untyped b, *untyped, d: untyped, ?e: untyped, **untyped) -> ApplicationTest::User::ActiveRecord_Relation
+        def self.by_status: (?) -> ApplicationTest::User::ActiveRecord_Relation
+        extend ApplicationTest::User::ActiveRecord_Persistence_ClassMethods
+        include ApplicationTest::User::GeneratedAssociationMethods
+        include ApplicationTest::User::GeneratedAttributeMethods
+      end
+
+      module ApplicationTest::User::GeneratedRelationMethods
+        def params: (untyped a, ?untyped b, *untyped, d: untyped, ?e: untyped, **untyped) -> ApplicationTest::User::ActiveRecord_Relation
+
+        def by_status: (?) -> ApplicationTest::User::ActiveRecord_Relation
+
+        def empty: () -> ApplicationTest::User::ActiveRecord_Relation
+      end
+    RBS
+    unless expect == actual
+      t.error("expect=\n```rbs\n#{expect}```\n, but got \n```rbs\n#{actual}```\n")
+    end
+  end
+
   def test_check_typo_only(t)
     Orthoses::Rails::Application.new(
       Orthoses::Store.new(->{})


### PR DESCRIPTION
The type definition for `GeneratedRelationMethods` via `scope` in `Orthoses::ActiveRecord::Scope` is more specific than that in `Orthoses::ActiveRecord::Relation`. The type definition in `Orthoses::ActiveRecord::Scope` was being unintentionally dropped due to the execution order of `use` in `Orthoses::Rails::Application#call`. So I fixed it.

### Expected

```rbs
module ApplicationTest::User::GeneratedRelationMethods
  def params: (untyped a, ?untyped b, *untyped, d: untyped, ?e: untyped, **untyped) -> ApplicationTest::User::ActiveRecord_Relation

  def by_status: (?) -> ApplicationTest::User::ActiveRecord_Relation

  def empty: () -> ApplicationTest::User::ActiveRecord_Relation
end
```

### Actual

```rbs
module ApplicationTest::User::GeneratedRelationMethods
  def empty: (?) -> untyped

  def params: (?) -> untyped

  def by_status: (?) -> untyped
end
```